### PR TITLE
Populate administrators table by seed

### DIFF
--- a/app/controllers/administrators_controller.rb
+++ b/app/controllers/administrators_controller.rb
@@ -1,5 +1,6 @@
 class AdministratorsController < ApplicationController
   skip_before_action :check_authorized, only: [:new, :create]
+  before_action :check_environment
 
   def new
     @administrator = Administrator.new
@@ -9,5 +10,11 @@ class AdministratorsController < ApplicationController
     @administrator = Administrator.create(params.require(:administrator).permit(:username, :password))
     session[:administrator_id] = @administrator.id
     redirect_to '/welcome'
+  end
+
+  private
+
+  def check_environment
+    raise ActionController::RoutingError.new("Not found") unless Rails.env.development?
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,10 @@
 class ApplicationController < ActionController::Base
   before_action :check_authorized
 
+  helper_method :form_selection
+  helper_method :current_user
+  helper_method :logged_in?
+
   def main_page
     render "layouts/application"
   end
@@ -8,17 +12,16 @@ class ApplicationController < ActionController::Base
   def form_selection(objects, accessor)
     objects.each_with_object([]) { |elem, memo| memo << [elem.public_send(accessor), elem.id] }
   end
-  helper_method :form_selection
 
   def current_user
     Administrator.find_by(id: session[:administrator_id])
   end
-  helper_method :current_user
 
   def logged_in?
     current_user.present?
   end
-  helper_method :logged_in?
+
+  private
 
   def check_authorized
     redirect_to '/login' unless logged_in?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,6 +5,7 @@ class UsersController < ApplicationController
   # GET /users.json
   def index
     @users = User.all
+    @admins = Administrator.all
   end
 
   # GET /users/1

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -23,3 +23,14 @@
     <% end %>
   </tbody>
 </table>
+
+<h1>Admins</h1>
+<table>
+  <tbody>
+  <% @admins.each do |admin| %>
+    <tr>
+      <td><%= admin.username %></td>
+    </tr>
+  <% end %>
+  </tbody>
+</table>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,22 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+# Admins
+[
+  { username: "splantio", password_digest: "$2a$12$kGIyW2fX9dyTjOF6mb2JYucRyuyLlaaAuCmZn9jK7oQ230FSKvJIi" },
+].each do |admin_data|
+  next if Administrator.find_by(username: admin_data[:username]).present?
+  Administrator.create(username:  admin_data[:username], password_digest: admin_data[:password_digest])
+end
+
+# Houses
+%w(
+  Gryffindor
+  Slytherin
+  Hufflepuff
+  Ravenclaw
+).each do |name|
+  next if House.find_by(name: name).present?
+  House.create(name: name)
+end

--- a/test/controllers/administrators_controller_test.rb
+++ b/test/controllers/administrators_controller_test.rb
@@ -1,12 +1,14 @@
 require 'test_helper'
 
 class AdministratorsControllerTest < ActionDispatch::IntegrationTest
-  test "should get new" do
+  test "should get new in development" do
+    Rails.stubs(env: ActiveSupport::StringInquirer.new("development"))
     get new_administrator_url
     assert_response :success
   end
 
-  test "should create administrator" do
+  test "should create administrator in development" do
+    Rails.stubs(env: ActiveSupport::StringInquirer.new("development"))
     assert_difference('Administrator.count', 1) do
       post(
         administrators_url,
@@ -20,5 +22,29 @@ class AdministratorsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to welcome_url
+  end
+
+  test "should not get new when not in development" do
+    Rails.stubs(env: ActiveSupport::StringInquirer.new("production"))
+    assert_raises(ActionController::RoutingError, "Not found") do
+      get new_administrator_url
+    end
+  end
+
+  test "should not create administrator when not in development" do
+    Rails.stubs(env: ActiveSupport::StringInquirer.new("production"))
+    assert_raises(ActionController::RoutingError, "Not found") do
+      assert_difference('Administrator.count', 0) do
+        post(
+          administrators_url,
+          params: {
+            administrator: {
+              username: "biz",
+              password: "is a free elf",
+            },
+          },
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
This will disable the ability to create administrators in production. To add administrators going forward:

1. Run the app locally with `rails server`
2. Navigate to `http://localhost:3000/administrators/new`
3. Add username and password that you'd like in production, create admin user.
4. In a DB viewer like Sql Pro or TablePlus, navigate to the created record in the `administrators` table.
5. Copy the `password_digest`
6. Add a line to the "Admin" array in `/db/seed.rb` with the username and password digest
7. Open a PR to get approved as admin
8. (@splantio) Seed the database in production over Heroku CLI by running the `rake db:seed` task.